### PR TITLE
fix(release workflow): do not pass GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,5 +8,4 @@ jobs:
   release:
     uses: carpasse/reusable-workflows/.github/workflows/release.yml@main
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
GH sets is automatically and the action fails if you set it