### PR TITLE
fix(semantic-release): remove release notes from release commit

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -58,7 +58,7 @@
           "package-lock.json",
           "package.json"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
it breaks conventional commits format and the validation fails